### PR TITLE
Resolve error with creating `lvm-thin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ cmd/docker-machine-driver-proxmox-ve/docker-machine-driver-proxmox-ve
 
 # MacOS stuff
 .DS_Store
+
+# Visual Studio Code stuff
+.history
+*.code-workspace

--- a/cmd/docker-machine-driver-proxmox-ve/Makefile
+++ b/cmd/docker-machine-driver-proxmox-ve/Makefile
@@ -1,3 +1,3 @@
 all:
-	GOOS=linux GOARCH=amd64 go build -o docker-machine-driver-proxmoxve.linux-amd64
-	GOOS=darwin GOARCH=amd64 go build -o docker-machine-driver-proxmoxve.macos-amd64
+	GOOS=linux GOARCH=amd64 go build -o docker-machine-driver-proxmox.linux-amd64
+	GOOS=darwin GOARCH=amd64 go build -o docker-machine-driver-proxmox.macos-amd64

--- a/cmd/docker-machine-driver-proxmox-ve/main.go
+++ b/cmd/docker-machine-driver-proxmox-ve/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	proxmox "github.com/lnxbil/docker-machine-driver-proxmox-ve"
+
 	"github.com/docker/machine/libmachine/drivers/plugin"
-	proxmoxve "github.com/lnxbil/docker-machine-driver-proxmox-ve"
 )
 
 func main() {
-	plugin.RegisterDriver(proxmoxve.NewDriver("default", ""))
+	plugin.RegisterDriver(proxmox.NewDriver("default", ""))
 }

--- a/proxmox.go
+++ b/proxmox.go
@@ -310,6 +310,7 @@ type NodesNodeQemuPostParameter struct {
 	Pool      string // optional, Add the VM to the specified pool.
 	Cores     string // optional, The number of cores per socket.
 	Cdrom     string // optional, This is an alias for option -ide2
+	CPU       string // optional, Set KVM CPU optimization flags
 }
 
 type nNodesNodeQemuPostParameter struct {

--- a/proxmoxdriver.go
+++ b/proxmoxdriver.go
@@ -383,6 +383,8 @@ func (d *Driver) Create() error {
 
 	if d.StorageType == "qcow2" {
 		npp.SCSI0 = d.Storage + ":" + d.VMID + "/" + volume.Filename
+	} else if d.StorageType == "raw" {
+		npp.SCSI0 = d.Storage + ":" + volume.Filename
 	}
 	d.debugf("Creating VM '%s' with '%d' of memory", npp.VMID, npp.Memory)
 	taskid, err := d.driver.NodesNodeQemuPost(d.Node, &npp)


### PR DESCRIPTION
Fix mistake in creatin volume ID for `lvm-thin` with 'raw' storage type.

Before creating 'lvm-thin', you need apply [patch](https://forum.proxmox.com/threads/proxmox-api-unable-to-create-vm-already-exists-on-node.62868/#post-286849),because Proxmox VE have error in perl script.