### PR TITLE
Including args to choice scsi model

### DIFF
--- a/proxmox.go
+++ b/proxmox.go
@@ -304,6 +304,7 @@ type NodesNodeQemuPostParameter struct {
 	Agent     string // optional, Enable/disable Qemu GuestAgent.
 	Net0      string
 	Name      string // optional, Set a name for the VM. Only used on the configuration web interface.
+	Scsihw    string   // optional, SCSI controller model
 	SCSI0     string // optional, Use volume as VIRTIO hard disk (n is 0 to 15).
 	Ostype    string // optional, Specify guest operating system.
 	KVM       string // optional, Enable/disable KVM hardware virtualization.

--- a/proxmoxdriver.go
+++ b/proxmoxdriver.go
@@ -42,6 +42,7 @@ type Driver struct {
 	Pool            string // pool to add the VM to (necessary for users with only pool permission)
 	Storage         string // internal PVE storage name
 	StorageType     string // Type of the storage (currently QCOW2 and RAW)
+	Scsihw			string // Model of controller scsi ( currently lsi | lsi53c810 | megasas | pvscsi | virtio-scsi-pci | virtio-scsi-single )
 	DiskSize        string // disk size in GB
 	Memory          int    // memory in GB
 	StorageFilename string
@@ -126,6 +127,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "proxmoxve-proxmox-pool",
 			Usage:  "pool to attach to",
 			Value:  "",
+		},
+		mcnflag.StringFlag{
+			EnvVar: "PROXMOXVE_VM_SCSI_CONTROLLER",
+			Name:   "proxmoxve-vm-scsihw",
+			Usage:  "scsi controller model (default: virtio-scsi-pci)",
+			Value:  "virtio-scsi-pci",
 		},
 		mcnflag.StringFlag{
 			EnvVar: "PROXMOXVE_VM_STORAGE_PATH",
@@ -242,6 +249,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Pool = flags.String("proxmoxve-proxmox-pool")
 
 	// VM configuration
+	d.Scsihw = flags.String("proxmoxve-vm-scsihw")
 	d.DiskSize = flags.String("proxmoxve-vm-storage-size")
 	d.Storage = flags.String("proxmoxve-vm-storage-path")
 	d.StorageType = strings.ToLower(flags.String("proxmoxve-vm-storage-type"))
@@ -421,6 +429,7 @@ func (d *Driver) Create() error {
 		Memory:    d.Memory,
 		Cores:     d.Cores,
 		Net0:      "virtio,bridge=vmbr0",
+		Scsihw:	   d.Scsihw,
 		SCSI0:     d.StorageFilename,
 		Ostype:    "l26",
 		Name:      d.BaseDriver.MachineName,


### PR DESCRIPTION
I detected that the creation of vm on pve cluster is slow, so I verified that if I change the default scsi model from lsi to virtio, the process works very well, and faster.
My cluster uses CEPH like software defined storage.
Creating the args proxmoxve-vm-scsihw, could allow that the user select the appropriate model for his  environment or needs