### PR TITLE
support for using clones+cloud-init

### DIFF
--- a/proxmox.go
+++ b/proxmox.go
@@ -681,6 +681,7 @@ type ConfigReturn struct {
 		CPU     string  `json:"cpu"`
 		ONBoot  IntBool `json:"onboot"`
 		SSHKeys string  `json:"sshkeys"`
+		Smbios1 string  // optional, Specify SMBIOS type 1 fields.
 	} `json:"data"`
 }
 

--- a/proxmox.go
+++ b/proxmox.go
@@ -317,6 +317,8 @@ type NodesNodeQemuPostParameter struct {
 	Scsihw     string // SCSI controller model.
 	Onboot     string // Specifies whether a VM will be started during system bootup.
 	Protection string // Sets the protection flag of the VM. This will disable the remove VM and remove disk operations.
+	NUMA       string // Enable/disable NUMA
+	CPU        string // Emulated CPU type.
 }
 
 type nNodesNodeQemuPostParameter struct {


### PR DESCRIPTION
This adds support for using clone+cloud-init images.

Basic requirement of the `template` are:

- quemu-guest installed
- cloud-init installed

Currently only 2 changed flags are needed to make it work:

- `--proxmoxve-provision-strategy clone`
- `--proxmoxve-vm-clone-vmid <vmid>`

~~I've not tested on `full` clones yet, my storage setup supports shallow cloning so I enjoy the space saving etc.~~
Full clones tested.

There are some other minor updates/fixes/additions as well.