### PR TITLE
Allow set PVE API port

### DIFF
--- a/proxmox.go
+++ b/proxmox.go
@@ -40,12 +40,13 @@ type ProxmoxVE struct {
 }
 
 // GetProxmoxVEConnectionByValues is a wrapper for GetProxmoxVEConnection with strings as input
-func GetProxmoxVEConnectionByValues(username string, password string, realm string, hostname string) (*ProxmoxVE, error) {
+func GetProxmoxVEConnectionByValues(username string, password string, realm string, hostname string, port int) (*ProxmoxVE, error) {
 	return GetProxmoxVEConnection(&ProxmoxVE{
 		Username: username,
 		password: password,
 		Realm:    realm,
 		Host:     hostname,
+		Port:     port,
 	})
 }
 

--- a/proxmox_test.go
+++ b/proxmox_test.go
@@ -22,16 +22,16 @@ func TestSuccessfulConnection(t *testing.T) {
 	}
 }
 func TestWrongPass(t *testing.T) {
-	username, _, realm, host := GetProxmoxAccess()
-	_, err := dockermachinedriverproxmoxve.GetProxmoxVEConnectionByValues(username, "wrong_password", realm, host)
+	username, _, realm, host, port := GetProxmoxAccess()
+	_, err := dockermachinedriverproxmoxve.GetProxmoxVEConnectionByValues(username, "wrong_password", realm, host, port)
 	if err == nil {
 		t.Log(err)
 		t.Error()
 	}
 }
 func TestWrongUser(t *testing.T) {
-	_, password, realm, host := GetProxmoxAccess()
-	_, err := dockermachinedriverproxmoxve.GetProxmoxVEConnectionByValues("root", password, realm, host)
+	_, password, realm, host, port:= GetProxmoxAccess()
+	_, err := dockermachinedriverproxmoxve.GetProxmoxVEConnectionByValues("root", password, realm, host, port)
 	if err == nil {
 		t.Log(err)
 		t.Error()
@@ -39,8 +39,8 @@ func TestWrongUser(t *testing.T) {
 }
 
 func TestEmptyPass(t *testing.T) {
-	username, _, realm, host := GetProxmoxAccess()
-	_, err := dockermachinedriverproxmoxve.GetProxmoxVEConnectionByValues(username, "", realm, host)
+	username, _, realm, host, port := GetProxmoxAccess()
+	_, err := dockermachinedriverproxmoxve.GetProxmoxVEConnectionByValues(username, "", realm, host, port)
 	if err != nil && err.Error() != "You have to provide a password" {
 		t.Log(err)
 		t.Error()
@@ -48,8 +48,8 @@ func TestEmptyPass(t *testing.T) {
 }
 
 func TestWrongHost(t *testing.T) {
-	username, password, realm, _ := GetProxmoxAccess()
-	_, err := dockermachinedriverproxmoxve.GetProxmoxVEConnectionByValues(username, password, realm, "127.0.0.1")
+	username, password, realm, _, port := GetProxmoxAccess()
+	_, err := dockermachinedriverproxmoxve.GetProxmoxVEConnectionByValues(username, password, realm, "127.0.0.1", port)
 	if err == nil {
 		t.Log(err)
 		t.Error()

--- a/testconfig.json.example
+++ b/testconfig.json.example
@@ -1,5 +1,6 @@
 {
     "host":"10.255.0.5",
+    "port":"8006",
     "user":"root",
     "realm": "pam",
     "password":"P@ssw0rd",

--- a/testconfig_test.go
+++ b/testconfig_test.go
@@ -17,6 +17,7 @@ import (
 // ProxmoxConfig represents all needed login information
 type ProxmoxConfig struct {
 	Host     string `json:"host"`
+	Port     int    `json:"port"`
 	User     string `json:"user"`
 	Password string `json:"password"`
 	Realm    string `json:"realm"`
@@ -43,9 +44,9 @@ func GetProxmoxConfigInstance() *ProxmoxConfig {
 }
 
 // GetProxmoxAccess gets working proxmox ve access information
-func GetProxmoxAccess() (string, string, string, string) {
+func GetProxmoxAccess() (string, string, string, string, int) {
 	i := GetProxmoxConfigInstance()
-	return i.User, i.Password, i.Realm, i.Host
+	return i.User, i.Password, i.Realm, i.Host, i.Port
 }
 
 // GetProxmoxNode return the defined test node


### PR DESCRIPTION
I publish my PVE cluster to the internet, so i have https://domain.com:443 url.
So simple fix for now.